### PR TITLE
Reloads the scene when petey dies

### DIFF
--- a/Assets/Scenes/Entity Controllers/Petey/PlayerDeath.cs
+++ b/Assets/Scenes/Entity Controllers/Petey/PlayerDeath.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class PlayerDeath : MonoBehaviour
+{
+    private Scene scene;
+    // Start is called before the first frame update
+    void Start()
+    {
+        scene = SceneManager.GetActiveScene();
+    }
+
+    private void OnDestroy()
+    {
+        SceneManager.LoadScene(scene.name, LoadSceneMode.Single);
+    }
+}

--- a/Assets/Scenes/Entity Controllers/Petey/PlayerDeath.cs.meta
+++ b/Assets/Scenes/Entity Controllers/Petey/PlayerDeath.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fa10f8474eb8dae49bbc2c432c837022
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Game Manager Files/Save Manager/Saves/SampleScene BACKUP_checkpoints.txt
+++ b/Assets/Scenes/Game Manager Files/Save Manager/Saves/SampleScene BACKUP_checkpoints.txt
@@ -1,2 +1,0 @@
-Checkpoint=Inactive
-Checkpoint (1)=Active

--- a/Assets/Scenes/Game Manager Files/Save Manager/Saves/SampleScene BACKUP_checkpoints.txt.meta
+++ b/Assets/Scenes/Game Manager Files/Save Manager/Saves/SampleScene BACKUP_checkpoints.txt.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: fab66350541a14c4792129a06ce116ad
-TextScriptImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
With this PR, the scene reloads when Petey dies, instead of him just disappearing. (This only works if you attach the PlayerDeath.cs script to petey!)